### PR TITLE
Add required cable to BTT Microprobe mod

### DIFF
--- a/Printer Mods/Probes/BTT Microprobe/README.md
+++ b/Printer Mods/Probes/BTT Microprobe/README.md
@@ -14,6 +14,7 @@ The Probe cable is plugged into the TH0 pins on the MCU - GPIO27
 - 2x m2.5x10 for Probe Mount
 - 12x 3x2mm Magnets
 - 4x M2.5x6 BHCS (Included in Positron Kit)
+- JST PH 2Pin Female + JST PH 3Pin Female to JST GH 5Pin Female Connector (**not** included with BTT Microprobe)
 
 # Installation Instructions
 1. Glue 6x 3x2mm Magnets into the `Probe_Heatsink_Mount`


### PR DESCRIPTION
Just so other people know that they'll need this to actually connect the BTT Microprobe!

(Please double check that this is correct - I omitted the "2.0" from the name because when searching through Amazon listings for the parts I needed to make my own cable I didn't see it mentioned very often. Note: I have no idea what I'm doing, but that's never stopped me before! :D)